### PR TITLE
[WnB] 카카오 소셜 회원가입/로그인

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from users.views import UserAdditionalInfoView
+from users.views import KakaoOauthView, UserAdditionalInfoView
 
 urlpatterns = [
+    path('/kakao/oauth', KakaoOauthView.as_view()),
     path('/additional-info', UserAdditionalInfoView.as_view())
 ]

--- a/wnb/settings.py
+++ b/wnb/settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
     'reservations',
     'hosts',
     'core',
+    'django_extensions'
 ]
 
 MIDDLEWARE = [

--- a/wnb/urls.py
+++ b/wnb/urls.py
@@ -1,4 +1,5 @@
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
+    path('users', include('users.urls'))
 ]


### PR DESCRIPTION
## :: 최근 작업 주제
- [x]  기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 카카오 소셜 회원가입/로그인/데코레이터 구현
- unit test 작성

<br />

## :: 구현 사항 설명
1. 카카오 소셜 회원가입/로그인
   - 프론트가 헤더에 'ACCESS_TOKEN'을 담아서 보내줍니다.
   - 카카오 서버로 'ACCESS_TOKEN'을 담아 요청을 보내면 kakao_id, kakao_profile, email 정보를 가져올 수 있습니다.
   - WnB DB에 저장되지 않은 User라면 DB에 저장하고 'SignUp Success' 메세지와 status=201(Created)을 보내줍니다.
   - WnB에 등록된 User라면 'SignIn Success' 메세지와 토큰을 보내줍니다.


<br />
<br />

2. 데코레이터

  <img width="1250" alt="스크린샷 2022-08-06 오전 1 20 16" src="https://user-images.githubusercontent.com/78359232/183124028-b5bd3f8c-bfa7-4830-9555-ac9ed66c2dc4.png">

- 유효하지 않은 토큰을 보낸 경우 INVALID_TOKEN, 400을 반환합니다.

  
  <img width="1254" alt="스크린샷 2022-08-06 오전 1 19 39" src="https://user-images.githubusercontent.com/78359232/183124059-bc3d3b0b-f9b7-498a-b8f8-89515d687496.png">

- 헤더에 'Authorization=토큰'이 없는 경우 KEY_ERROR, 400을 반환합니다.

  
  <img width="1251" alt="스크린샷 2022-08-06 오전 1 19 52" src="https://user-images.githubusercontent.com/78359232/183124374-fb42c05a-3ca7-4426-863a-cdc45c1fdefd.png">

- 유효한 토큰의 경우에만 의도한 메세지가 나오는 걸 확인했습니다.


3. unit test
    - 소셜 로그인의 경우 외부 API를 사용하기 때문에 magic mock을 사용했습니다.

<br />
<br />

## :: 성장 포인트
- 카카오 공식문서를 읽으며 Oauth 개념 및 동작 방식을 이해했습니다. 
- 원격 API를 호출할 때는 requests 모듈을 사용합니다.
- get_or_create() : 객체를 조회할 때 유용하게 사용하는 메서드로, 첫번째 인자에는 조회된 객체가 담기고 두번째 인자에는 TRUE/FALSE의 불린값이 담깁니다.
- 토큰을 생성할 때는 겹치지 않는 고유한 값(pk)을 사용하는 게 좋습니다.
- 페이지이동(redirect)은 프론트에서 담당합니다.

- merge와 rebase의 차이
  - merge는 두 브랜치를 합치는 merge commit이 생기며 모든 커밋 내역이 보존됩니다.
  - rebase는 브랜치의 기준점을 재설정하며 병합하는 방식이고 커밋 내역들을 하나로 합칩니다.
 
- unit test
  - 100% 이해는 못했지만 세션 들을때보다 조금은 이해한 것 같습니다.

## :: 기타 질문 및 특이 사항
- 없음