### PR TITLE
[WnB] 유저 추가 정보 입력 API

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,167 @@
-from django.test import TestCase
+import json
+import jwt
 
-# Create your tests here.
+from django.test    import TestCase, Client
+
+from users.models   import User
+from django.conf    import settings
+
+class UserAdditionalInfoViewTest(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id                = 1,
+            kakao_id          = '12345667',
+            email             = 'test1@test.com',
+            kakao_profile_img = 'http://test1.com'
+        )
+    
+        User.objects.create(
+            id                = 2,
+            kakao_id          = '4444444',
+            email             = 'test2@test.com',
+            kakao_profile_img = 'http://test2.com'
+        )
+        
+        User.objects.create(
+            id                = 3,
+            kakao_id          = '7777777',
+            email             = 'test3@test.com',
+            kakao_profile_img = 'http://test3.com',
+            phone_number      = '010-4444-4444'
+        )
+    
+    def tearDown(self):
+        User.objects.all().delete()
+    
+    def test_fail_user_patch_additional_info_because_no_token(self):
+        client = Client()
+        
+        data = {
+            'first_name'  : '은형',
+            'last_name'   : '전',
+            'phone_number': '010-1223-1234',
+            'birth_day'   : '2022-08-08'
+        }
+        
+        response = client.patch('/users/additional-info', json.dumps(data), content_type='application/json')
+        
+        self.assertEqual(response.json(), {'message':'INVALID_TOKEN'})
+        self.assertEqual(response.status_code, 400)
+        
+    def test_fail_user_patch_additional_info_because_wrong_token(self):
+        client = Client()
+        
+        data = {
+            'first_name'  : '은형',
+            'last_name'   : '전',
+            'phone_number': '010-1223-1234',
+            'birth_day'   : '2022-08-08'
+        }
+
+        headers  = {"HTTP_AUTHORIZATION": 'fake_token'}
+        response = client.patch('/users/additional-info', json.dumps(data), content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(), {'message':'INVALID_TOKEN'})
+        self.assertEqual(response.status_code, 400)
+        
+    def test_fail_user_patch_additional_info_because_already_exist_number(self):
+        client = Client()
+        
+        data = {
+            'first_name'  : '은형',
+            'last_name'   : '전',
+            'phone_number': '010-4444-4444',
+            'birth_day'   : '2022-08-08'
+        }
+
+        token    = jwt.encode({'id': User.objects.get(id=2).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers  = {"HTTP_AUTHORIZATION": token}
+        response = client.patch('/users/additional-info', json.dumps(data), content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(), {'message':'PHONE_NUMBER_ALREADY_EXIST'})
+        self.assertEqual(response.status_code, 400)
+                
+    def test_fail_user_patch_additional_info_because_key_error_no_birth_day(self):
+        client = Client()
+        
+        data = {
+            'first_name'  : '은형',
+            'last_name'   : '전',
+            'phone_number': '010-4444-4444'
+        }
+
+        token    = jwt.encode({'id': User.objects.get(id=2).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers  = {"HTTP_AUTHORIZATION": token}
+        response = client.patch('/users/additional-info', json.dumps(data), content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(), {'message':'KEY_ERROR'})
+        self.assertEqual(response.status_code, 400)
+        
+    def test_fail_user_patch_additional_info_because_first_name_validation(self):
+        client = Client()
+        
+        data = {
+            'first_name'  : 'eunhyung',
+            'last_name'   : '전',
+            'phone_number': '010-4444-4444',
+            'birth_day'   : '2022-08-08'
+        }
+
+        token    = jwt.encode({'id': User.objects.get(id=2).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers  = {"HTTP_AUTHORIZATION": token}
+        response = client.patch('/users/additional-info', json.dumps(data), content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(), {'message':"['FIRST_NAME_ERROR']"})
+        self.assertEqual(response.status_code, 400)
+        
+    def test_fail_user_patch_additional_info_because_last_name_validation(self):
+        client = Client()
+        
+        data = {
+            'first_name'  : '은형',
+            'last_name'   : 'jeon',
+            'phone_number': '010-8787-1203',
+            'birth_day'   : '2022-08-08'
+        }
+
+        token    = jwt.encode({'id': User.objects.get(id=2).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers  = {"HTTP_AUTHORIZATION": token}
+        response = client.patch('/users/additional-info', json.dumps(data), content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(), {'message':"['LAST_NAME_ERROR']"})
+        self.assertEqual(response.status_code, 400)
+        
+    def test_fail_user_patch_additional_info_because_phone_number_validation(self):
+        client = Client()
+        
+        data = {
+            'first_name'  : '은형',
+            'last_name'   : '전',
+            'phone_number': '01012341234',
+            'birth_day'   : '2022-08-08'
+        }
+
+        token    = jwt.encode({'id': User.objects.get(id=2).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers  = {"HTTP_AUTHORIZATION": token}
+        response = client.patch('/users/additional-info', json.dumps(data), content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(), {'message':"['PHONE_NUMBER_ERROR']"})
+        self.assertEqual(response.status_code, 400)
+        
+    def test_success_user_patch_additional_info(self):
+        client = Client()
+        
+        data = {
+            'first_name'  : '은형',
+            'last_name'   : '전',
+            'phone_number': '010-1223-1234',
+            'birth_day'   : '2022-08-08'
+        }
+
+        token    = jwt.encode({'id': User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers  = {"HTTP_AUTHORIZATION": token}
+        response = client.patch('/users/additional-info', json.dumps(data), content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(), {'message':'USER_INFO_UPDATED', 'user_name':f'{User.objects.get(id=1).last_name + User.objects.get(id=1).first_name}'})
+        self.assertEqual(response.status_code, 201)
+

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from users.views import UserAdditionalInfoView
+
+urlpatterns = [
+    path('/additional-info', UserAdditionalInfoView.as_view())
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,41 @@
-from django.shortcuts import render
+import json
 
-# Create your views here.
+from django.http        import JsonResponse
+from django.views       import View
+from django.forms       import ValidationError
+
+from users.models       import User
+from core.utils         import check_first_name, check_last_name, check_phone_number, signin_decorator
+
+class UserAdditionalInfoView(View):
+    @signin_decorator
+    def patch(self, request):
+        try: 
+            user = request.user
+            data = json.loads(request.body)
+            
+            first_name   = data['first_name']
+            last_name    = data['last_name']
+            phone_number = data['phone_number']
+            birth_day    = data['birth_day']
+                      
+            check_first_name(first_name)
+            check_last_name(last_name)
+            check_phone_number(phone_number)
+            
+            if User.objects.filter(phone_number = phone_number):
+                return JsonResponse({'message':'PHONE_NUMBER_ALREADY_EXIST'}, status=400)
+            
+            user.first_name   = first_name
+            user.last_name    = last_name
+            user.phone_number = phone_number
+            user.birth_day    = birth_day
+            user.save()
+
+            return JsonResponse({'message':'USER_INFO_UPDATED'}, status=201)
+            
+        except KeyError:
+            return JsonResponse({'message':'KEY_ERROR'}, status=400)
+        
+        except ValidationError as e:
+            return JsonResponse({'message':f'{e}'}, status=400)

--- a/wnb/settings.py
+++ b/wnb/settings.py
@@ -1,5 +1,5 @@
 from pathlib     import Path
-from my_settings import DATABASES, SECRET_KEY
+from my_settings import DATABASES, SECRET_KEY, ALGORITHM
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -10,6 +10,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = SECRET_KEY
+ALGORITHM  = ALGORITHM
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 카카오토큰에서 가져오지 못하는 데이터들 추가 입력받기
- 테스트 코드 작성

<br />

## :: 구현 사항 설명
1. UserAdditionalInfoView
    - url : '/users/additional-info'
    - 로그인 데코레이터를 통해 사용자를 확인합니다.
    - 이미 데코레이터로 사용자 검증을 거치기 때문에 DB에 존재하는 User인지 확인할 필요가 없습니다.
    - first_name / last_name / phone_number / birth_day를 입력받습니다.
    - 정규표현식으로 입력된 데이터를 확인하고, 핸드폰 번호는 중복이 불가합니다.
    - User의 정보를 업데이트합니다.
    - 요구되는 키값이 없다면 'KEY_ERROR'을 반환합니다.
    - 정규표현식을 테스트 못하면 정규표현식에 작성했었던 에러메세지를 보여줍니다.

2. TestCode
    - UserAdditionalInfoView에서 반환하는 모든 응답값을 테스트하는 코드를 작성했습니다.

<br />


## :: 성장 포인트
- 포스트맨 사용에 점점 익숙해지고 있습니다.
  - 포스트맨으로 데코레이터 기능을 확인하려면 header에 토큰값을 넣어야합니다.
  - patch를 사용하려면 body에 raw data로 text-type을 json형식으로 아래처럼 넣어줍니다.
  - `{
      "first_name" : "이름",
      "last_name" : "성",
      "phone_number" : "연락처",
      "birth_day" : "생년월일"
  }`
- 테스트 코드 작성법이 처음보다는 덜 어렵습니다.


<br />

## :: 기타 질문 및 특이 사항
- 업데이트 뷰의 url을 만들 때 '/users/<int:user_id>/info'로 할까도 생각해봤습니다. 어떻게 해야 좋을까요?
- WnB에 User가 처음 등록되면 사용자의 추가 정보를 입력받아야합니다. 
- 로그인 데코레이터를 사용하면 request안에 이미 유저 정보가 저장되어 있습니다. 따라서 user_id를 전달받을 필요가 없습니다. 
- 그래서 데코레이터를 사용했고 url를 '/users/additional-info'로 만들었습니다. 