### PR TITLE
[WnB] 예약 메인페이지 GET API 구현 (& 이전 동일 POST)

### DIFF
--- a/reservations/tests.py
+++ b/reservations/tests.py
@@ -9,7 +9,7 @@ from rooms.models           import *
 from users.models           import User
 from hosts.models           import Host
 
-class ReservationTest(TestCase):
+class MainReservationTest(TestCase):
     def setUp(self):
         User.objects.create(
                     id                  = 1,
@@ -140,7 +140,7 @@ class ReservationTest(TestCase):
         Image.objects.all().delete()
         RoomType.objects.all().delete()
 
-    def test_success_reservation_get(self):
+    def test_success_Mainreservation_get(self):
         client      = Client()
         token       = jwt.encode({'id': User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
         headers     = {'HTTP_Authorization' : token}
@@ -149,45 +149,41 @@ class ReservationTest(TestCase):
         body =  {
                 "RESULT" : [{
                     'reservation_number'        : "100",
-                    'user_name'                 : "kim doyeon",
                     'room'                      : "펜션1",
-                    'price'                     : "10000.00",
-                    'people'                    : 10,
                     'check_in'                  : "2022-08-02",
                     'check_out'                 : "2022-08-10",
-                    'img'                       : "https://images.unsplash.com/photo-1610641818989-c2051b5e2cfd?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80"
+                    'images'                    : "https://images.unsplash.com/photo-1610641818989-c2051b5e2cfd?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
+                    'address'                   : "강원도",
+                    'detail_address'            : "대관령면"
                 },
                 {   'reservation_number'        : "200",
-                    'user_name'                 : "kim doyeon",
                     'room'                      : "펜션2",
-                    'price'                     : "10000.00",
-                    'people'                    : 10,
                     'check_in'                  : "2022-08-12",
                     'check_out'                 : "2022-08-15",
-                    'img'                       : "https://images.unsplash.com/photo-1610641818989-c2051b5e2cfd?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80"
-                }
-                ]
+                    'images'                    : "https://images.unsplash.com/photo-1610641818989-c2051b5e2cfd?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
+                    'address'                   : "강원도",
+                    'detail_address'            : "강릉"
+                }]
             }
-        
         self.assertEqual(response.json(), body)
         self.assertEqual(response.status_code, 200)
     
     def test_Success_Reservation_post(self):
         client = Client()
-                    
+
         data = {
-                    "id"                  : 1,
-                    "check_in"            : "2022-08-02",
-                    "check_out"           : "2022-08-10",
-                    "people"              : 10,
-                    "price"               : 10000.00,
-                    "room"                : 1
+            "id"                : 1,
+            "check_in"          : "2022-08-02",
+            "check_out"         : "2022-08-10",
+            "people"            : 10,
+            "price"             : 10000.00,
+            "room"              : 1
         }
 
-        token    = jwt.encode({'id': User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
-        headers  = {"HTTP_AUTHORIZATION": token}
+        token = jwt.encode({'id': User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers = {"HTTP_AUTHORIZATION": token}
         response = client.post('/reservations', json.dumps(data), content_type='application/json', **headers)
-        
+
         self.assertEqual(response.json(), {"MESSAGE": "SUCCESS"})
         self.assertEqual(response.status_code, 201)
 
@@ -195,36 +191,36 @@ class ReservationTest(TestCase):
         client = Client()
 
         data = {
-                    "id"                  : 1,
-                    "check_in"            : "2022-08-02",
-                    "check_out"           : "2022-08-10",
-                    "people"              : 10,
-                    "price"               : 10000.00,
-                    #"room"                : 1
+            "id"                : 1,
+            "check_in"          : "2022-08-02",
+            "check_out"         : "2022-08-10",
+            "people"            : 10,
+            "price"             : 10000.00,
+            # "room"            : 1
         }
 
-        token    = jwt.encode({'id': User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
-        headers  = {"HTTP_AUTHORIZATION": token}
+        token = jwt.encode({'id': User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers = {"HTTP_AUTHORIZATION": token}
         response = client.post('/reservations', json.dumps(data), content_type='application/json', **headers)
 
-        self.assertEqual(response.json(), {"MESSAGE" : "KEY_ERROR"})
+        self.assertEqual(response.json(), {"MESSAGE": "KEY_ERROR"})
         self.assertEqual(response.status_code, 400)
 
     def test_DoesNot_Exist_Room_Error_Reservation_post(self):
         client = Client()
 
         data = {
-                    "id"                  : 1,
-                    "check_in"            : "2022-08-02",
-                    "check_out"           : "2022-08-10",
-                    "people"              : 10,
-                    "price"               : 10000.00,
-                    "room"                : 100
+            "id"                : 1,
+            "check_in"          : "2022-08-02",
+            "check_out"         : "2022-08-10",
+            "people"            : 10,
+            "price"             : 10000.00,
+            "room"              : 100
         }
 
-        token    = jwt.encode({'id': User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
-        headers  = {"HTTP_AUTHORIZATION": token}
+        token = jwt.encode({'id': User.objects.get(id=1).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        headers = {"HTTP_AUTHORIZATION": token}
         response = client.post('/reservations', json.dumps(data), content_type='application/json', **headers)
 
-        self.assertEqual(response.json(), {"MESSAGE" : "DOESNOT_EXIST_ROOM"})
+        self.assertEqual(response.json(), {"MESSAGE": "DOESNOT_EXIST_ROOM"})
         self.assertEqual(response.status_code, 400)

--- a/reservations/urls.py
+++ b/reservations/urls.py
@@ -1,7 +1,7 @@
 from django.urls            import path
 
-from reservations.views     import ResevationsView
+from reservations.views     import MainResevationsView
 
 urlpatterns = [
-    path('', ResevationsView.as_view())
+    path('', MainResevationsView.as_view())
 ]

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -8,22 +8,20 @@ from reservations.models    import Reservation
 from rooms.models           import Room
 from core.utils             import signin_decorator
 
-class ResevationsView(View):
+class MainResevationsView(View):
     @signin_decorator
     def get(self, request): 
-        user            = request.user
         reservations    = Reservation.objects.select_related("room") \
                                              .prefetch_related("room__image_set") \
-                                             .filter(user = user)
+                                             .filter(user = request.user)
         result = [{
             'reservation_number'        : reservation.number,
-            'user_name'                 : reservation.user.last_name + " " + reservation.user.first_name,
             'room'                      : reservation.room.name,
-            'price'                     : reservation.price,
-            'people'                    : reservation.people,
             'check_in'                  : reservation.check_in,
             'check_out'                 : reservation.check_out,
-            'img'                       : reservation.room.image_set.all()[0].url
+            'images'                    : reservation.room.image_set.all()[0].url,
+            'address'                   : reservation.room.address,
+            'detail_address'            : reservation.room.detail_address
         } for reservation in reservations]
 
         return JsonResponse({"RESULT": result}, status=200)
@@ -31,23 +29,23 @@ class ResevationsView(View):
     @signin_decorator
     def post(self, request):
         try:
-            data                = json.loads(request.body)
-            user                = request.user
-            room                = Room.objects.get(id=data['room'])
-            check_in            = data['check_in']
-            check_out           = data['check_out']
-            people              = data['people']
-            price               = data['price']
-            number              = uuid.uuid1()
-            
+            data                    = json.loads(request.body)
+            user                    = request.user
+            room                    = Room.objects.get(id=data['room'])
+            check_in                = data['check_in']
+            check_out               = data['check_out']
+            people                  = data['people']
+            price                   = data['price']
+            number                  = uuid.uuid1()
+
             Reservation.objects.create(
-                        check_in        = check_in,
-                        check_out       = check_out,
-                        people          = people,
-                        room            = room,
-                        user            = user,
-                        price           = price,
-                        number          = number
+                check_in            = check_in,
+                check_out           = check_out,
+                people              = people,
+                room                = room,
+                user                = user,
+                price               = price,
+                number              = number
             )
 
             return JsonResponse({"MESSAGE": "SUCCESS"}, status=201)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 예약메인페이지  API GET구현
- 예약 API POST구현



## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 예약메인페이지  API GET구현

프론트엔드와 커뮤니케이션 후 GET함수를 호출하는 것을 예약의 메인페이지와 상세페이지로 나누었습니다.

2.  예약 API POST구현
예약 POST API는 이전 올린 API와 동일하여 같이 올렸습니다.
<br />



## :: 성장 포인트
커뮤니케이션의 중요성을 알게 되었습니다.

<br />

## :: 기타 질문 및 특이 사항
없습니다.